### PR TITLE
Correctly regex out the string literal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tassembly",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"main": "tassembly.js",
 	"devDependencies": {
 		"browserify": "*"

--- a/tassembly.js
+++ b/tassembly.js
@@ -65,10 +65,11 @@ function rewriteExpression (expr) {
 			}
 		} else if (c === "'") {
 			// skip over string literal
-			var literal = expr.slice(i).match(/'(?:[^\\']+|\\')*'/);
+			// skip over string literal
+			var literal = expr.slice(i).match(/'((?:(?!\').)+)/);
 			if (literal) {
-				res += literal[0];
-				i += literal[0].length - 1;
+				res += JSON.stringify(literal[1].replace(/\\'/g, "'"));
+				i += literal[0].length;
 			}
 		} else {
 			res += c;


### PR DESCRIPTION
Our temlating engine used to break on lines containing `\\` in the end since the regex wasn't correct.

cc @wikimedia/services